### PR TITLE
Add a license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Karlsruhe Institute of Technology, Institute for Measurement and Control Systems
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/package.xml
+++ b/package.xml
@@ -4,7 +4,7 @@
   <version>0.0.0</version>
   <description>This package cache arbitrary values which can be recalled by specifying a key</description>
 
-  <license>MRT</license>
+  <license>MIT</license>
   <maintainer email="lingguang.wang@kit.edu">Lingguang Wang</maintainer>
   <author email="lingguang.wang@kit.edu">Lingguang Wang</author>
   <url type="repository">https://gitlab.mrt.uni-karlsruhe.de/MRT/draft/util_caching</url>


### PR DESCRIPTION
Let's add a license here.
As discussed, we're selecting between BSD and MIT. I'd go for MIT as it's more clear (there are four differnt BSD licenses) and explicitly includes documentation etc.
See also [this StackExchange discussion](https://opensource.stackexchange.com/questions/217/what-are-the-essential-differences-between-the-bsd-and-mit-licences).

But, I'm open for BSD as well, if you think that's more appropriate.