### PR TITLE
Add python bindings

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,10 @@ RUN apt-get update && \
     apt-get install -y \
       build-essential \
       cmake \
-      libgtest-dev && \
+      libgtest-dev  \
+      pybind11-dev \
+      python3-dev \
+      python3-pybind11 && \
     apt-get clean
 
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ More usage please check the unittest.
 ## Python bindings
 
 The library can be used in Python via pybind11 bindings.
-Since util_caching is a template library,
+Since `util_caching` is a templated C++ library,
   you need to explicitly instantiate the template for the types you want to use in Python.
 For this, we provide convenience functions to bind the library for the desired types.
 Simply call them in a pybind11 module definition, e.g.:
@@ -133,8 +133,8 @@ find_package(util_caching REQUIRED)
 ### Building from source using CMake
 
 First make sure all dependencies are installed:
-- [Googletest](https://github.com/google/googletest) (only if you want to build unit tests)
-- [pybind11](https://pybind11.readthedocs.io/en/stable/) (only if you want to build Python bindings and unit tests)
+- [Googletest](https://github.com/google/googletest) (optional, if you want to build unit tests)
+- [pybind11](https://pybind11.readthedocs.io/en/stable/) (optional, if you want to build Python bindings and unit tests)
 
 See also the [`Dockerfile`](./Dockerfile) for how to install these packages under Debian or Ubuntu.
 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,13 @@ or by specifying one comparison policy and threshold (100ms for example), and re
 
 More usage please check the unittest.
 
+## Python bindings
+
+The library can be used in Python via pybind11 bindings.
+Since util_caching is a template library, we need to explicitly instantiate the template for the types we want to use in Python.
+For this, we provide the convenience functions `bindNumberBasedCache` and `bindTimeBasedCache`.
+Check the unit test for a usage example.
+
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -79,9 +79,24 @@ More usage please check the unittest.
 ## Python bindings
 
 The library can be used in Python via pybind11 bindings.
-Since util_caching is a template library, we need to explicitly instantiate the template for the types we want to use in Python.
-For this, we provide the convenience functions `bindNumberBasedCache` and `bindTimeBasedCache`.
-Check the unit test for a usage example.
+Since util_caching is a template library,
+  you need to explicitly instantiate the template for the types you want to use in Python.
+For this, we provide convenience functions to bind the library for the desired types.
+Simply call them in a pybind11 module definition, e.g.:
+
+```cpp
+PYBIND11_MODULE(util_caching, m) {
+    python_api::number_based::bindCache<double, double>(m);
+}
+```
+and use them in Python:
+
+```python
+from util_caching import Cache
+cache = Cache()
+cache.cache(1.0, 2.0)
+```
+We re-implemented all of the C++ unit tests in Python, so take a closer look at those for more advanced usage examples.
 
 
 ## Installation
@@ -119,6 +134,7 @@ find_package(util_caching REQUIRED)
 
 First make sure all dependencies are installed:
 - [Googletest](https://github.com/google/googletest) (only if you want to build unit tests)
+- [pybind11](https://pybind11.readthedocs.io/en/stable/) (only if you want to build Python bindings and unit tests)
 
 See also the [`Dockerfile`](./Dockerfile) for how to install these packages under Debian or Ubuntu.
 

--- a/include/util_caching/python_bindings.hpp
+++ b/include/util_caching/python_bindings.hpp
@@ -10,22 +10,40 @@ namespace util_caching::python_api {
 
 namespace py = pybind11;
 
+namespace number_based {
+namespace internal {
+template <typename CacheT, typename NumberT, typename... ComparisonPolicyTs>
+void bindPolicies(py::class_<CacheT, std::shared_ptr<CacheT>>& cacheClass) {
+    (cacheClass.def(
+         "cached",
+         [](CacheT& self, const NumberT& key, const ComparisonPolicyTs& policy) {
+             return self.template cached<ComparisonPolicyTs>(key, policy);
+         },
+         py::arg("key"),
+         py::arg("policy")),
+     ...);
+}
+} // namespace internal
+
+template <typename NumberT>
+void bindApproximatePolicy(py::module& module, const std::string& name = "ApproximateNumber") {
+    using ApproximateNumberT = policies::ApproximateNumber<NumberT>;
+    py::class_<ApproximateNumberT, std::shared_ptr<ApproximateNumberT>>(module, name.c_str())
+        .def(py::init<NumberT>(), py::arg("threshold"))
+        .def("__call__", &ApproximateNumberT::operator(), "Compare two numbers");
+}
+
 /*!
  * \brief Bindings for a Cache that is based on number comparisons
  *
  * This function binds the Cache class for a specific number-based key type (NumberT) and value type (ValueT).
  * Call this function once inside PYBIND11_MODULE macro to create a Python module with the bindings.
  */
-template <typename NumberT, typename ValueT, typename ThresholdNumberT = NumberT>
-void bindNumberBasedCache(py::module& module) {
+template <typename NumberT, typename ValueT, typename... ComparisonPolicies>
+void bindCache(py::module& module) {
     using CacheT = Cache<NumberT, ValueT>;
-    using ApproximateNumberT = policies::ApproximateNumber<ThresholdNumberT>;
-
-    py::class_<ApproximateNumberT, std::shared_ptr<ApproximateNumberT>>(module, "ApproximateNumber")
-        .def(py::init<ThresholdNumberT>(), py::arg("threshold"))
-        .def("__call__", &ApproximateNumberT::operator(), "Compare two values");
-
-    py::class_<CacheT, std::shared_ptr<CacheT>>(module, "Cache")
+    py::class_<CacheT, std::shared_ptr<CacheT>> cache(module, "Cache");
+    cache
         .def(py::init<>())
         // We cannot pass template parameters to python functions, therefore we need to explicitly bind all
         // instantiations to different python functions.
@@ -34,17 +52,36 @@ void bindNumberBasedCache(py::module& module) {
             "cached",
             [](CacheT& self, const NumberT& key) { return self.template cached<std::equal_to<NumberT>>(key); },
             py::arg("key"))
-        // Approximate match: using ApproximateNumber policy
-        .def(
-            "cached",
-            [](CacheT& self, const NumberT& key, const ApproximateNumberT& policy) {
-                return self.template cached<ApproximateNumberT>(key, policy);
-            },
-            py::arg("key"),
-            py::arg("policy"),
-            "Check if the value is approximately cached based on the given policy")
         .def("cache", &CacheT::cache, py::arg("key"), py::arg("value"))
         .def("reset", &CacheT::reset);
+
+    internal::bindPolicies<CacheT, NumberT, ComparisonPolicies...>(cache);
+}
+
+} // namespace number_based
+
+namespace time_based {
+
+namespace internal {
+template <typename CacheT, typename TimeT, typename... ComparisonPolicyTs>
+void bindPolicies(py::class_<CacheT, std::shared_ptr<CacheT>>& cache) {
+    (cache.def(
+         "cached",
+         [](CacheT& self, const TimeT& key, const ComparisonPolicyTs& policy) {
+             return self.template cached<ComparisonPolicyTs>(key, policy);
+         },
+         py::arg("key"),
+         py::arg("policy")),
+     ...);
+}
+} // namespace internal
+
+template <typename TimeT, typename ThresholdTimeUnitT>
+void bindApproximatePolicy(py::module& module, const std::string& name = "ApproximateTime") {
+    using ApproximateTimeT = policies::ApproximateTime<TimeT, ThresholdTimeUnitT>;
+    py::class_<ApproximateTimeT, std::shared_ptr<ApproximateTimeT>>(module, name.c_str())
+        .def(py::init<double>(), py::arg("threshold"))
+        .def("__call__", &ApproximateTimeT::operator(), "Compare two time points");
 }
 
 /*!
@@ -53,31 +90,21 @@ void bindNumberBasedCache(py::module& module) {
  * This function binds the Cache class for a specific time-based key type (TimeT) and value type (ValueT).
  * Call this function once inside PYBIND11_MODULE macro to create a Python module with the bindings.
  */
-template <typename TimeT, typename ValueT, typename ThresholdTimeUnitT = std::chrono::milliseconds>
-void bindTimeBasedCache(py::module& module) {
+template <typename TimeT, typename ValueT, typename... ComparisonPolicyTs>
+void bindCache(py::module& module) {
     using CacheT = Cache<TimeT, ValueT>;
-    using ApproximateTimeT = policies::ApproximateTime<TimeT, ThresholdTimeUnitT>;
 
-    py::class_<ApproximateTimeT>(module, "ApproximateTime")
-        .def(py::init<double>(), py::arg("threshold"))
-        .def("__call__", &ApproximateTimeT::operator(), "Compare two time points");
-
-    py::class_<CacheT, std::shared_ptr<CacheT>>(module, "Cache")
-        .def(py::init<>())
+    py::class_<CacheT, std::shared_ptr<CacheT>> cache(module, "Cache");
+    cache.def(py::init<>())
         .def(
             "cached",
             [](CacheT& self, const TimeT& key) { return self.template cached<std::equal_to<TimeT>>(key); },
             py::arg("key"))
-        .def(
-            "cached",
-            [](CacheT& self, const TimeT& key, const ApproximateTimeT& policy) {
-                return self.template cached<ApproximateTimeT>(key, policy);
-            },
-            py::arg("key"),
-            py::arg("policy"),
-            "Check if the value is approximately cached based on the given policy")
         .def("cache", &CacheT::cache, py::arg("key"), py::arg("value"))
         .def("reset", &CacheT::reset);
+
+    internal::bindPolicies<CacheT, TimeT, ComparisonPolicyTs...>(cache);
 }
 
+} // namespace time_based
 } // namespace util_caching::python_api

--- a/include/util_caching/python_bindings.hpp
+++ b/include/util_caching/python_bindings.hpp
@@ -12,98 +12,139 @@ namespace py = pybind11;
 
 namespace number_based {
 namespace internal {
+
+/*!
+ * \brief Bind the comparison policies to the Cache class
+ *
+ * This function binds the comparison policies to the Cache class. The policies
+ * are passed as variadic template arguments. The function overloads the
+ * `cached` function for each policy.
+ */
 template <typename CacheT, typename NumberT, typename... ComparisonPolicyTs>
-void bindPolicies(py::class_<CacheT, std::shared_ptr<CacheT>>& cacheClass) {
-    (cacheClass.def(
-         "cached",
-         [](CacheT& self, const NumberT& key, const ComparisonPolicyTs& policy) {
-             return self.template cached<ComparisonPolicyTs>(key, policy);
-         },
-         py::arg("key"),
-         py::arg("policy")),
-     ...);
+void bindPolicies(py::class_<CacheT, std::shared_ptr<CacheT>> &cacheClass) {
+  (cacheClass.def(
+       "cached",
+       [](CacheT &self, const NumberT &key, const ComparisonPolicyTs &policy) {
+         return self.template cached<ComparisonPolicyTs>(key, policy);
+       },
+       py::arg("key"), py::arg("policy")),
+   ...);
 }
 } // namespace internal
 
+/*!
+ * \brief Bind the ApproximateNumber policy
+ *
+ * This function adds bindings for the ApproximateNumber policy to the given
+ * python module under the given name.
+ */
 template <typename NumberT>
-void bindApproximatePolicy(py::module& module, const std::string& name = "ApproximateNumber") {
-    using ApproximateNumberT = policies::ApproximateNumber<NumberT>;
-    py::class_<ApproximateNumberT, std::shared_ptr<ApproximateNumberT>>(module, name.c_str())
-        .def(py::init<NumberT>(), py::arg("threshold"))
-        .def("__call__", &ApproximateNumberT::operator(), "Compare two numbers");
+void bindApproximatePolicy(py::module &module,
+                           const std::string &name = "ApproximateNumber") {
+  using ApproximateNumberT = policies::ApproximateNumber<NumberT>;
+  py::class_<ApproximateNumberT, std::shared_ptr<ApproximateNumberT>>(
+      module, name.c_str())
+      .def(py::init<NumberT>(), py::arg("threshold"))
+      .def("__call__", &ApproximateNumberT::operator(), "Compare two numbers");
 }
 
 /*!
  * \brief Bindings for a Cache that is based on number comparisons
  *
- * This function binds the Cache class for a specific number-based key type (NumberT) and value type (ValueT).
- * Call this function once inside PYBIND11_MODULE macro to create a Python module with the bindings.
+ * This function binds the Cache class for a specific number-based key type
+ * (NumberT) and value type (ValueT). Optionally, add a list of comparison
+ * policies to the list of template parameters. The `cached` function will be
+ * overloaded for each one of them. Call this function once inside
+ * PYBIND11_MODULE macro to create the bindings for the Cache class.
  */
 template <typename NumberT, typename ValueT, typename... ComparisonPolicies>
-void bindCache(py::module& module) {
-    using CacheT = Cache<NumberT, ValueT>;
-    py::class_<CacheT, std::shared_ptr<CacheT>> cache(module, "Cache");
-    cache
-        .def(py::init<>())
-        // We cannot pass template parameters to python functions, therefore we need to explicitly bind all
-        // instantiations to different python functions.
-        // We need to use the lambdas here to handle the seconds argument, defining the comparison policy.
-        .def(
-            "cached",
-            [](CacheT& self, const NumberT& key) { return self.template cached<std::equal_to<NumberT>>(key); },
-            py::arg("key"))
-        .def("cache", &CacheT::cache, py::arg("key"), py::arg("value"))
-        .def("reset", &CacheT::reset);
+void bindCache(py::module &module) {
+  using CacheT = Cache<NumberT, ValueT>;
+  py::class_<CacheT, std::shared_ptr<CacheT>> cache(module, "Cache");
+  cache
+      .def(py::init<>())
+      // We cannot pass template parameters to python functions, therefore we
+      // need to explicitly bind all instantiations to different python
+      // functions. We need to use the lambdas here to handle the seconds
+      // argument, defining the comparison policy.
+      .def(
+          "cached",
+          [](CacheT &self, const NumberT &key) {
+            return self.template cached<std::equal_to<NumberT>>(key);
+          },
+          py::arg("key"))
+      .def("cache", &CacheT::cache, py::arg("key"), py::arg("value"))
+      .def("reset", &CacheT::reset);
 
-    internal::bindPolicies<CacheT, NumberT, ComparisonPolicies...>(cache);
+  internal::bindPolicies<CacheT, NumberT, ComparisonPolicies...>(cache);
 }
 
 } // namespace number_based
 
 namespace time_based {
-
 namespace internal {
+
+/*!
+ * \brief Bind the comparison policies to the Cache class
+ *
+ * This function binds the comparison policies to the Cache class. The policies
+ * are passed as variadic template arguments. The function overloads the
+ * `cached` function for each policy.
+ */
 template <typename CacheT, typename TimeT, typename... ComparisonPolicyTs>
-void bindPolicies(py::class_<CacheT, std::shared_ptr<CacheT>>& cache) {
-    (cache.def(
-         "cached",
-         [](CacheT& self, const TimeT& key, const ComparisonPolicyTs& policy) {
-             return self.template cached<ComparisonPolicyTs>(key, policy);
-         },
-         py::arg("key"),
-         py::arg("policy")),
-     ...);
+void bindPolicies(py::class_<CacheT, std::shared_ptr<CacheT>> &cache) {
+  (cache.def(
+       "cached",
+       [](CacheT &self, const TimeT &key, const ComparisonPolicyTs &policy) {
+         return self.template cached<ComparisonPolicyTs>(key, policy);
+       },
+       py::arg("key"), py::arg("policy")),
+   ...);
 }
 } // namespace internal
 
+/*!
+ * \brief Bind the ApproximateTime policy
+ *
+ * This function adds bindings for the ApproximateTime policy to the given
+ * python module under the given name.
+ */
 template <typename TimeT, typename ThresholdTimeUnitT>
-void bindApproximatePolicy(py::module& module, const std::string& name = "ApproximateTime") {
-    using ApproximateTimeT = policies::ApproximateTime<TimeT, ThresholdTimeUnitT>;
-    py::class_<ApproximateTimeT, std::shared_ptr<ApproximateTimeT>>(module, name.c_str())
-        .def(py::init<double>(), py::arg("threshold"))
-        .def("__call__", &ApproximateTimeT::operator(), "Compare two time points");
+void bindApproximatePolicy(py::module &module,
+                           const std::string &name = "ApproximateTime") {
+  using ApproximateTimeT = policies::ApproximateTime<TimeT, ThresholdTimeUnitT>;
+  py::class_<ApproximateTimeT, std::shared_ptr<ApproximateTimeT>>(module,
+                                                                  name.c_str())
+      .def(py::init<double>(), py::arg("threshold"))
+      .def("__call__", &ApproximateTimeT::operator(),
+           "Compare two time points");
 }
 
 /*!
- * \brief Bindings for a Cache that is based on time comparisons
+ * \brief Bindings for a Cache that is based on time comparisons.
  *
- * This function binds the Cache class for a specific time-based key type (TimeT) and value type (ValueT).
- * Call this function once inside PYBIND11_MODULE macro to create a Python module with the bindings.
+ * This function binds the Cache class for a specific time-based key type
+ * (TimeT) and value type (ValueT). Optionally, add a list of comparison
+ * policies to the list of template parameters. The `cached` function will be
+ * overloaded for each one of them. Call this function once inside
+ * PYBIND11_MODULE macro to create the bindings for the Cache class.
  */
 template <typename TimeT, typename ValueT, typename... ComparisonPolicyTs>
-void bindCache(py::module& module) {
-    using CacheT = Cache<TimeT, ValueT>;
+void bindCache(py::module &module) {
+  using CacheT = Cache<TimeT, ValueT>;
 
-    py::class_<CacheT, std::shared_ptr<CacheT>> cache(module, "Cache");
-    cache.def(py::init<>())
-        .def(
-            "cached",
-            [](CacheT& self, const TimeT& key) { return self.template cached<std::equal_to<TimeT>>(key); },
-            py::arg("key"))
-        .def("cache", &CacheT::cache, py::arg("key"), py::arg("value"))
-        .def("reset", &CacheT::reset);
+  py::class_<CacheT, std::shared_ptr<CacheT>> cache(module, "Cache");
+  cache.def(py::init<>())
+      .def(
+          "cached",
+          [](CacheT &self, const TimeT &key) {
+            return self.template cached<std::equal_to<TimeT>>(key);
+          },
+          py::arg("key"))
+      .def("cache", &CacheT::cache, py::arg("key"), py::arg("value"))
+      .def("reset", &CacheT::reset);
 
-    internal::bindPolicies<CacheT, TimeT, ComparisonPolicyTs...>(cache);
+  internal::bindPolicies<CacheT, TimeT, ComparisonPolicyTs...>(cache);
 }
 
 } // namespace time_based

--- a/include/util_caching/python_bindings.hpp
+++ b/include/util_caching/python_bindings.hpp
@@ -1,0 +1,83 @@
+#include <chrono>
+
+#include <pybind11/chrono.h>
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+#include "cache.hpp"
+
+namespace util_caching::python_api {
+
+namespace py = pybind11;
+
+/*!
+ * \brief Bindings for a Cache that is based on number comparisons
+ *
+ * This function binds the Cache class for a specific number-based key type (NumberT) and value type (ValueT).
+ * Call this function once inside PYBIND11_MODULE macro to create a Python module with the bindings.
+ */
+template <typename NumberT, typename ValueT, typename ThresholdNumberT = NumberT>
+void bindNumberBasedCache(py::module& module) {
+    using CacheT = Cache<NumberT, ValueT>;
+    using ApproximateNumberT = policies::ApproximateNumber<ThresholdNumberT>;
+
+    py::class_<ApproximateNumberT, std::shared_ptr<ApproximateNumberT>>(module, "ApproximateNumber")
+        .def(py::init<ThresholdNumberT>(), py::arg("threshold"))
+        .def("__call__", &ApproximateNumberT::operator(), "Compare two values");
+
+    py::class_<CacheT, std::shared_ptr<CacheT>>(module, "Cache")
+        .def(py::init<>())
+        // We cannot pass template parameters to python functions, therefore we need to explicitly bind all
+        // instantiations to different python functions.
+        // We need to use the lambdas here to handle the seconds argument, defining the comparison policy.
+        .def(
+            "cached",
+            [](CacheT& self, const NumberT& key) { return self.template cached<std::equal_to<NumberT>>(key); },
+            py::arg("key"))
+        // Approximate match: using ApproximateNumber policy
+        .def(
+            "cached",
+            [](CacheT& self, const NumberT& key, const ApproximateNumberT& policy) {
+                return self.template cached<ApproximateNumberT>(key, policy);
+            },
+            py::arg("key"),
+            py::arg("policy"),
+            "Check if the value is approximately cached based on the given policy")
+        .def("cache", &CacheT::cache, py::arg("key"), py::arg("value"))
+        .def("reset", &CacheT::reset);
+}
+
+/*!
+ * \brief Bindings for a Cache that is based on time comparisons
+ *
+ * This function binds the Cache class for a specific time-based key type (TimeT) and value type (ValueT).
+ * Call this function once inside PYBIND11_MODULE macro to create a Python module with the bindings.
+ */
+template <typename TimeT, typename ValueT, typename ThresholdTimeUnitT = std::chrono::milliseconds>
+void bindTimeBasedCache(py::module& module) {
+    using CacheT = Cache<TimeT, ValueT>;
+    using ApproximateTimeT = policies::ApproximateTime<TimeT, ThresholdTimeUnitT>;
+
+    py::class_<ApproximateTimeT>(module, "ApproximateTime")
+        .def(py::init<double>(), py::arg("threshold"))
+        .def("__call__", &ApproximateTimeT::operator(), "Compare two time points");
+
+    py::class_<CacheT, std::shared_ptr<CacheT>>(module, "Cache")
+        .def(py::init<>())
+        .def(
+            "cached",
+            [](CacheT& self, const TimeT& key) { return self.template cached<std::equal_to<TimeT>>(key); },
+            py::arg("key"))
+        .def(
+            "cached",
+            [](CacheT& self, const TimeT& key, const ApproximateTimeT& policy) {
+                return self.template cached<ApproximateTimeT>(key, policy);
+            },
+            py::arg("key"),
+            py::arg("policy"),
+            "Check if the value is approximately cached based on the given policy")
+        .def("cache", &CacheT::cache, py::arg("key"), py::arg("value"))
+        .def("reset", &CacheT::reset);
+}
+
+} // namespace util_caching::python_api

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -43,6 +43,11 @@ endif()
 ###################
 
 find_package(GTest)
+find_package(pybind11 CONFIG)
+
+if(NOT GTEST_FOUND AND NOT pybind11_FOUND)
+  message(WARNING "Neither GTest nor pybind11 found. Cannot compile tests!")
+endif()
 
 # Find installed lib and its dependencies, if this is build as top-level project
 if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
@@ -50,13 +55,14 @@ if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
 endif()
 
 
-###########
-## Build ##
-###########
+####################
+## C++ Unit Tests ##
+####################
 
 if(GTEST_FOUND)
   file(GLOB_RECURSE _tests CONFIGURE_DEPENDS "*.cpp" "*.cc")
   list(FILTER _tests EXCLUDE REGEX "${CMAKE_CURRENT_BINARY_DIR}")
+  list(REMOVE_ITEM _tests "${CMAKE_CURRENT_SOURCE_DIR}/python_bindings.cpp")
 
   foreach(_test ${_tests})
     get_filename_component(_test_name ${_test} NAME_WE)
@@ -80,6 +86,42 @@ if(GTEST_FOUND)
       WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     )
   endforeach()
-else()
-  message(WARNING "GTest not found. Cannot compile tests!")
 endif()
+
+#######################
+## Python Unit Tests ##
+#######################
+
+if(pybind11_FOUND)
+  # Find Python3 to run tests via ctest
+  find_package(Python3 REQUIRED)
+
+  # Python bindings modules
+  pybind11_add_module(util_caching_py
+    python_bindings.cpp
+  )
+  target_link_libraries(util_caching_py PUBLIC
+    ${PROJECT_NAME}
+  )
+
+  file(GLOB_RECURSE _py_tests CONFIGURE_DEPENDS "*.py")
+
+  # Copy Python test files to build directory
+  foreach(_py_test ${_py_tests})
+    get_filename_component(_py_test_name ${_py_test} NAME)
+    string(REGEX REPLACE "-test" "" PY_TEST_NAME ${_py_test_name})
+    set(PY_TEST_NAME ${PROJECT_NAME}-pytest-${PY_TEST_NAME})
+
+    message(STATUS
+      "Adding python unittest \"${PY_TEST_NAME}\" with working dir ${PROJECT_SOURCE_DIR}/${TEST_FOLDER} \n _test: ${_py_test}"
+    )
+
+    configure_file(${_py_test} ${PY_TEST_NAME} COPYONLY)
+
+    add_test(NAME ${PY_TEST_NAME}
+      COMMAND ${Python3_EXECUTABLE} ${PY_TEST_NAME}
+      WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+    )
+  endforeach()
+endif()
+

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -101,7 +101,7 @@ if(pybind11_FOUND)
     python_bindings.cpp
   )
   target_link_libraries(util_caching_py PUBLIC
-    ${PROJECT_NAME}
+    util_caching
   )
 
   file(GLOB_RECURSE _py_tests CONFIGURE_DEPENDS "*.py")

--- a/test/python_bindings.cpp
+++ b/test/python_bindings.cpp
@@ -22,7 +22,7 @@ struct SomePolicyWithoutParams {
 };
 
 /*!
- * \brief The python module definition that allows running equivalent unit tests in python.
+ * \brief The python module definition that allows running python unit tests equivalent to the native C++ ones.
  */
 PYBIND11_MODULE(util_caching_py, mainModule) {
     // Just some aliases to make the code more readable

--- a/test/python_bindings.cpp
+++ b/test/python_bindings.cpp
@@ -2,6 +2,7 @@
 
 #include "cache.hpp"
 #include "python_bindings.hpp"
+#include "types.hpp"
 
 namespace py = pybind11;
 
@@ -9,8 +10,11 @@ using namespace util_caching;
 
 PYBIND11_MODULE(util_caching_py, mainModule) {
     py::module numberBased = mainModule.def_submodule("number_based");
-    python_api::bindNumberBasedCache<double, double>(numberBased);
+    python_api::number_based::bindApproximatePolicy<double>(numberBased);
+    python_api::number_based::bindCache<double, double, policies::ApproximateNumber<double>>(numberBased);
 
     py::module timeBased = mainModule.def_submodule("time_based");
-    python_api::bindTimeBasedCache<Time, double, std::chrono::milliseconds>(timeBased);
+    python_api::time_based::bindApproximatePolicy<Time, std::chrono::milliseconds>(timeBased);
+    python_api::time_based::bindCache<Time, double, policies::ApproximateTime<Time, std::chrono::milliseconds>>(
+        timeBased);
 }

--- a/test/python_bindings.cpp
+++ b/test/python_bindings.cpp
@@ -1,0 +1,16 @@
+#include <pybind11/pybind11.h>
+
+#include "cache.hpp"
+#include "python_bindings.hpp"
+
+namespace py = pybind11;
+
+using namespace util_caching;
+
+PYBIND11_MODULE(util_caching_py, mainModule) {
+    py::module numberBased = mainModule.def_submodule("number_based");
+    python_api::bindNumberBasedCache<double, double>(numberBased);
+
+    py::module timeBased = mainModule.def_submodule("time_based");
+    python_api::bindTimeBasedCache<Time, double, std::chrono::milliseconds>(timeBased);
+}

--- a/test/python_bindings.cpp
+++ b/test/python_bindings.cpp
@@ -8,6 +8,12 @@ namespace py = pybind11;
 
 using namespace util_caching;
 
+/*!
+ * \brief A policy that always returns true
+ *
+ * Custom policies have to be defined in C++ and then bound to Python.
+ * To overload the `cache` function, the policy has to be passed as a template parameter to the `bindCache` function.
+ */
 struct SomePolicyWithoutParams {
     SomePolicyWithoutParams() = default;
     bool operator()(const Time& /*lhs*/, const Time& /*rhs*/) const {
@@ -15,22 +21,40 @@ struct SomePolicyWithoutParams {
     }
 };
 
+/*!
+ * \brief The python module definition that allows running equivalent unit tests in python.
+ */
 PYBIND11_MODULE(util_caching_py, mainModule) {
+    // Just some aliases to make the code more readable
     using ApproximateNumberT = policies::ApproximateNumber<double>;
     using ApproximateTimeT = policies::ApproximateTime<Time, std::chrono::milliseconds>;
     using ApproximateTimeSecondsT = policies::ApproximateTime<Time, std::chrono::seconds>;
 
+    // Since we want to use this policy in python, we need to be able to instatiate it there
     py::class_<SomePolicyWithoutParams, std::shared_ptr<SomePolicyWithoutParams>>(mainModule, "SomePolicyWithoutParams")
         .def(py::init<>())
         .def("__call__", &SomePolicyWithoutParams::operator());
 
+    // Adding a submodule is optional but a good way to structure the bindings
     py::module numberBased = mainModule.def_submodule("number_based");
+    // If we want to use a policy, we need to bind it. For the builtin policies, we can use this convenience function.
     python_api::number_based::bindApproximatePolicy<double>(numberBased);
-    python_api::number_based::bindCache<double, double, ApproximateNumberT>(numberBased);
+    // The core binding, the cache class itself.
+    python_api::number_based::bindCache<double,            // KeyType
+                                        double,            // Value type
+                                        ApproximateNumberT // Optionally, a list of comparison policies, each one will
+                                                           // overload the `cached` function
+                                        >(numberBased);
 
+    // Same as above, but for the time-based cache
     py::module timeBased = mainModule.def_submodule("time_based");
+    // We can bind the builtin comparison policy for different time units but then we have to name them differently
     python_api::time_based::bindApproximatePolicy<Time, std::chrono::milliseconds>(timeBased, "ApproximateTime");
     python_api::time_based::bindApproximatePolicy<Time, std::chrono::seconds>(timeBased, "ApproximateTimeSeconds");
-    python_api::time_based::bindCache<Time, double, ApproximateTimeT, ApproximateTimeSecondsT, SomePolicyWithoutParams>(
-        timeBased);
+    // The core binding, the cache class itself.
+    python_api::time_based::bindCache<Time,             // Key type
+                                      double,           // Value type
+                                      ApproximateTimeT, // A list of all comparison policies we intend to use
+                                      ApproximateTimeSecondsT,
+                                      SomePolicyWithoutParams>(timeBased);
 }

--- a/test/python_bindings.cpp
+++ b/test/python_bindings.cpp
@@ -8,13 +8,29 @@ namespace py = pybind11;
 
 using namespace util_caching;
 
+struct SomePolicyWithoutParams {
+    SomePolicyWithoutParams() = default;
+    bool operator()(const Time& /*lhs*/, const Time& /*rhs*/) const {
+        return true;
+    }
+};
+
 PYBIND11_MODULE(util_caching_py, mainModule) {
+    using ApproximateNumberT = policies::ApproximateNumber<double>;
+    using ApproximateTimeT = policies::ApproximateTime<Time, std::chrono::milliseconds>;
+    using ApproximateTimeSecondsT = policies::ApproximateTime<Time, std::chrono::seconds>;
+
+    py::class_<SomePolicyWithoutParams, std::shared_ptr<SomePolicyWithoutParams>>(mainModule, "SomePolicyWithoutParams")
+        .def(py::init<>())
+        .def("__call__", &SomePolicyWithoutParams::operator());
+
     py::module numberBased = mainModule.def_submodule("number_based");
     python_api::number_based::bindApproximatePolicy<double>(numberBased);
-    python_api::number_based::bindCache<double, double, policies::ApproximateNumber<double>>(numberBased);
+    python_api::number_based::bindCache<double, double, ApproximateNumberT>(numberBased);
 
     py::module timeBased = mainModule.def_submodule("time_based");
-    python_api::time_based::bindApproximatePolicy<Time, std::chrono::milliseconds>(timeBased);
-    python_api::time_based::bindCache<Time, double, policies::ApproximateTime<Time, std::chrono::milliseconds>>(
+    python_api::time_based::bindApproximatePolicy<Time, std::chrono::milliseconds>(timeBased, "ApproximateTime");
+    python_api::time_based::bindApproximatePolicy<Time, std::chrono::seconds>(timeBased, "ApproximateTimeSeconds");
+    python_api::time_based::bindCache<Time, double, ApproximateTimeT, ApproximateTimeSecondsT, SomePolicyWithoutParams>(
         timeBased);
 }

--- a/test/util_caching.py
+++ b/test/util_caching.py
@@ -2,7 +2,7 @@ import os
 import unittest
 import time
 
-from util_caching_py import number_based, time_based
+from util_caching_py import number_based, time_based, SomePolicyWithoutParams
 
 
 class CacheTest(unittest.TestCase):
@@ -18,7 +18,8 @@ class CacheTest(unittest.TestCase):
         self.cache_by_time = time_based.Cache()
         self.approximate_number_policy = number_based.ApproximateNumber(0.5)
         self.approximate_time_policy = time_based.ApproximateTime(100)
-        self.approximate_time_policy_2 = time_based.ApproximateTime(1000)
+        self.approximate_time_policy_2 = time_based.ApproximateTimeSeconds(1)
+        self.dummy_policy = SomePolicyWithoutParams()
 
     def test_with_number_key(self):
         self.assertIsNone(self.cache_by_number.cached(self.key1))
@@ -70,10 +71,18 @@ class CacheTest(unittest.TestCase):
         self.assertIsNone(
             self.cache_by_time.cached(self.time3, self.approximate_time_policy)
         )
+        # exactly 1s after rounding to integer
+        self.assertTrue(
+            self.cache_by_time.cached(self.time3, self.approximate_time_policy_2)
+        )
         # expect 2s after rounding to integer which is over threshold
         self.assertIsNone(
             self.cache_by_time.cached(self.time4, self.approximate_time_policy_2)
         )
+
+    def test_with_other_comparison_policy(self):
+        self.cache_by_time.cache(self.time1, 1.0)
+        self.assertTrue(self.cache_by_time.cached(self.time2, self.dummy_policy))
 
 
 if __name__ == "__main__":

--- a/test/util_caching.py
+++ b/test/util_caching.py
@@ -1,0 +1,86 @@
+import os
+import unittest
+import time
+
+from util_caching_py import number_based, time_based
+
+
+class CacheTest(unittest.TestCase):
+    def setUp(self):
+        self.key1 = 1.0
+        self.key2 = 1.2
+        self.key3 = 1.6
+        self.time1 = time.time()
+        self.time2 = self.time1 + 0.01  # 10 milliseconds later
+        self.time3 = self.time1 + 1.1  # 1100 milliseconds later
+        self.time4 = self.time1 + 2.1  # 2100 milliseconds later
+        self.cache_by_number = number_based.Cache()
+        self.cache_by_time = time_based.Cache()
+        self.approximate_number_policy = number_based.ApproximateNumber(0.5)
+        self.approximate_time_policy = time_based.ApproximateTime(100)
+        self.approximate_time_policy_2 = time_based.ApproximateTime(1000)
+
+    def test_with_number_key(self):
+        self.assertIsNone(self.cache_by_number.cached(self.key1))
+        self.cache_by_number.cache(self.key1, 1.0)
+
+        # exact match
+        self.assertTrue(self.cache_by_number.cached(self.key1))
+        self.assertEqual(self.cache_by_number.cached(self.key1), 1.0)
+
+        # approximate match
+        self.assertTrue(
+            self.cache_by_number.cached(self.key2, self.approximate_number_policy)
+        )
+        self.assertEqual(
+            self.cache_by_number.cached(self.key2, self.approximate_number_policy),
+            1.0,
+        )
+
+        # over threshold
+        self.assertIsNone(
+            self.cache_by_number.cached(self.key3, self.approximate_number_policy)
+        )
+
+    def test_with_time_key(self):
+        self.assertIsNone(self.cache_by_time.cached(self.time1))
+        self.cache_by_time.cache(self.time1, 1.0)
+
+        # exact match
+        self.assertTrue(self.cache_by_time.cached(self.time1))
+        self.assertEqual(self.cache_by_time.cached(self.time1), 1.0)
+
+        # approximate match with milliseconds
+        self.assertTrue(
+            self.cache_by_time.cached(self.time2, self.approximate_time_policy)
+        )
+        self.assertEqual(
+            self.cache_by_time.cached(self.time2, self.approximate_time_policy), 1.0
+        )
+
+        # approximate match with seconds
+        self.assertTrue(
+            self.cache_by_time.cached(self.time2, self.approximate_time_policy_2)
+        )
+        self.assertEqual(
+            self.cache_by_time.cached(self.time2, self.approximate_time_policy_2), 1.0
+        )
+
+        # over threshold
+        self.assertIsNone(
+            self.cache_by_time.cached(self.time3, self.approximate_time_policy)
+        )
+        # expect 2s after rounding to integer which is over threshold
+        self.assertIsNone(
+            self.cache_by_time.cached(self.time4, self.approximate_time_policy_2)
+        )
+
+
+if __name__ == "__main__":
+    header = "Running " + os.path.basename(__file__)
+
+    print("=" * len(header))
+    print(header)
+    print("=" * len(header) + "\n")
+    unittest.main(exit=False)
+    print("=" * len(header) + "\n")


### PR DESCRIPTION
This contributes python bindings. Since this is a template C++ library, the python bindings have to be compiled at a later point in time, when the types are known. Therefore, we don't ship the bindings directly but rather add a convenience function that allows binding the types once the template arguments are known.

When pybind is available and `BUILD_TEST=TRUE`, a python module is built that allows running unit tests (almost) equivalent to the C++ ones.

#minor