### PR TITLE
Use deploy key to run version bump action

### DIFF
--- a/.github/workflows/bump-version-and-create-release.yaml
+++ b/.github/workflows/bump-version-and-create-release.yaml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Check out the repository
         uses: actions/checkout@v4
+        with:
+          ssh-key: ${{ secrets.DEPLOY_KEY }}
 
       - name: Read version from file
         run: |


### PR DESCRIPTION
This allows to bypass branch protections, see
https://github.com/orgs/community/discussions/25305#discussioncomment-10728028 for reference.

I created a [ruleset](https://github.com/KIT-MRT/util_caching/settings/rules/2575812) that essentially does the same thing as the [branch protection](https://github.com/KIT-MRT/util_caching/settings/branches) we had in place earlier except that it allows certain entities to bypass these restrictions.

I therefore created a deploy key as described in the discussion I mentioned above and use that when checking out the repo before pushing the updated version.