### PR TITLE
Split compute-version and update-version-file into separate jobs

### DIFF
--- a/.github/workflows/bump-version-and-create-release.yaml
+++ b/.github/workflows/bump-version-and-create-release.yaml
@@ -7,7 +7,7 @@ on:
       - main
 
 jobs:
-  bump-version:
+  compute-version:
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     permissions:
@@ -17,8 +17,6 @@ jobs:
     steps:
       - name: Check out the repository
         uses: actions/checkout@v4
-        with:
-          ssh-key: ${{ secrets.DEPLOY_KEY }}
 
       - name: Read version from file
         run: |
@@ -37,23 +35,37 @@ jobs:
           INITIAL_VERSION: ${{ env.INITIAL_VERSION }}
           WITH_V: true
 
+
+  update-version-file:
+    if: github.event.pull_request.merged == true
+    needs: compute-version
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v4
+        with:
+          ssh-key: ${{ secrets.DEPLOY_KEY }}
+
       - name: Update version file with new version
         run: |
-          echo "New version: ${{ steps.bump_version.outputs.new_tag }}"
-          echo "VERSION=${{ steps.bump_version.outputs.new_tag }}" > version
+          echo "New version: ${{ needs.compute-version.outputs.new_tag }}"
+          echo "VERSION=${{ needs.compute-version.outputs.new_tag }}" > version
           git config --local user.name "github-actions[bot]"
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git add version
-          git commit -m "chore: update version file to ${{ steps.bump_version.outputs.new_tag }}"
+          git commit -m "chore: update version file to ${{ needs.compute-version.outputs.new_tag }}"
           git push
 
       - name: Push new tag
         run: |
-          git tag ${{ steps.bump_version.outputs.new_tag }}
-          git push origin ${{ steps.bump_version.outputs.new_tag }}
+          git tag ${{ needs.compute-version.outputs.new_tag }}
+          git push origin ${{ needs.compute-version.outputs.new_tag }}
+
 
   create-release:
-    needs: bump-version
+    needs: [compute-version, update-version-file]
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -61,7 +73,8 @@ jobs:
       - name: Check out the repository and pull the new tag
         uses: actions/checkout@v4
         with:
-          ref: ${{ needs.bump-version.outputs.new_tag }}
+          fetch-depth: 0
+          ref: ${{ needs.compute-version.outputs.new_tag }}
 
       - name: Build release packages
         uses: docker/build-push-action@v6
@@ -81,6 +94,6 @@ jobs:
         uses: ncipollo/release-action@v1
         with:
           artifacts: "/tmp/artifacts/release/*"
-          tag: ${{ needs.bump-version.outputs.new_tag }}
+          tag: ${{ needs.compute-version.outputs.new_tag }}
           body: ${{ github.event.pull_request.body }}
 

--- a/.github/workflows/bump-version-and-create-release.yaml
+++ b/.github/workflows/bump-version-and-create-release.yaml
@@ -25,7 +25,7 @@ jobs:
           echo "Current version: $INITIAL_VERSION"
           echo "INITIAL_VERSION=${INITIAL_VERSION}" >> $GITHUB_ENV
 
-      - name: Bump version and push tag
+      - name: Bump version
         id: bump_version
         uses: anothrNick/github-tag-action@v1
         env:
@@ -37,7 +37,6 @@ jobs:
 
 
   update-version-file:
-    if: github.event.pull_request.merged == true
     needs: compute-version
     runs-on: ubuntu-latest
     permissions:
@@ -82,13 +81,13 @@ jobs:
           context: .
           push: false
           tags: |
-            util_caching_release
+            release_builder
           target: release
 
       - name: Copy release packages
         run: |
           mkdir -p /tmp/artifacts/
-          docker run --rm -v /tmp/artifacts:/tmp/artifacts util_caching_release cp -r /release /tmp/artifacts/
+          docker run --rm -v /tmp/artifacts:/tmp/artifacts release_builder cp -r /release /tmp/artifacts/
 
       - name: Create Release
         uses: ncipollo/release-action@v1


### PR DESCRIPTION
This fixes an issue with the release pipeline.

The version bump action does not seem to work with a repository cloned via ssh. This PR therefore splits this into two jobs: One job to just compute the new version using an https clone and a second job that updated the version file and creates a tag. This one then uses the deploy key to bypass the branch protections for the automated changes.

This fixes the issue (tested on a protected devel branch) and also adds a separation of concerns for the different parts of the pipeline.
