### PR TITLE
Test released deb package

### DIFF
--- a/.github/workflows/run-release-tests.yaml
+++ b/.github/workflows/run-release-tests.yaml
@@ -1,0 +1,24 @@
+name: Run release tests
+
+on:
+  release:
+    types:
+      - released
+
+jobs:
+  build-and-run-release-tests:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Build release test Docker image
+        uses: docker/build-push-action@v6
+        with:
+          push: false
+          tags: |
+            ghcr.io/kit-mrt/util_caching_release_tests
+          target: release_test
+
+      - name: Run unit tests with/against released version
+        run: |
+          docker run --rm ghcr.io/kit-mrt/util_caching_release_tests
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,6 +46,27 @@ RUN cmake .. && \
 
 
 
+FROM base AS release_test
+
+# This downloads the latest util_caching debian release and adds it to the docker image
+# This "bloats" the image. But otherwise, we'd have to installing wget and ca-certificates
+# temporarily to download and install the package in one docker layer…
+ADD https://github.com/KIT-MRT/util_caching/releases/latest/download/libutil-caching-dev.deb /tmp/debfiles/
+
+# Install util_caching from release debian package
+RUN dpkg -i /tmp/debfiles/*.deb && \
+    rm -rf /tmp/debfiles
+
+COPY test /tmp/util_caching_test
+WORKDIR /tmp/util_caching_test/build
+
+RUN cmake .. && \
+    cmake --build . -j9
+
+CMD ["cmake", "--build", ".", "--target", "test"]
+
+
+
 FROM base AS install
 
 # Install util_caching

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,8 +1,53 @@
+cmake_minimum_required(VERSION 3.22)
+
+
+######################
+## Project settings ##
+######################
+
+# We support building this as top-level project, e.g. in order to test the lib installation
+project(util_caching_tests
+  LANGUAGES CXX
+)
+
+
+###############
+## C++ setup ##
+###############
+
+# Only do these if this is the main project, and not if it is included through add_subdirectory
+if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
+  # Require C++17
+  set(CMAKE_CXX_STANDARD 17)
+  set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+  # Let's ensure -std=c++xx instead of -std=g++xx
+  set(CMAKE_CXX_EXTENSIONS OFF)
+
+  # Let's nicely support folders in IDEs
+  set_property(GLOBAL PROPERTY USE_FOLDERS ON)
+
+  # Allow clangd and others to properly understand this C++ project
+  set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
+  # Testing only available if this is the main project
+  # Note this needs to be done in the main CMakeLists
+  # since it calls enable_testing, which must be in the
+  # main CMakeLists.
+  include(CTest)
+endif()
+
+
 ###################
 ## Find packages ##
 ###################
 
 find_package(GTest)
+
+# Find installed lib and its dependencies, if this is build as top-level project
+if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
+  find_package(util_caching REQUIRED)
+endif()
 
 
 ###########
@@ -11,12 +56,13 @@ find_package(GTest)
 
 if(GTEST_FOUND)
   file(GLOB_RECURSE _tests CONFIGURE_DEPENDS "*.cpp" "*.cc")
+  list(FILTER _tests EXCLUDE REGEX "${CMAKE_CURRENT_BINARY_DIR}")
 
   foreach(_test ${_tests})
     get_filename_component(_test_name ${_test} NAME_WE)
     # make sure we add only one -test to the target
     string(REGEX REPLACE "-test" "" TEST_TARGET_NAME ${_test_name})
-    set(TEST_TARGET_NAME ${PROJECT_NAME}-gtest-${TEST_TARGET_NAME})
+    set(TEST_TARGET_NAME util_caching-gtest-${TEST_TARGET_NAME})
 
     message(STATUS
       "Adding gtest unittest \"${TEST_TARGET_NAME}\" with working dir ${PROJECT_SOURCE_DIR}/${TEST_FOLDER} \n _test: ${_test}"
@@ -26,7 +72,7 @@ if(GTEST_FOUND)
 
     target_link_libraries(${TEST_TARGET_NAME} PUBLIC
       ${GTEST_BOTH_LIBRARIES} pthread
-      ${PROJECT_NAME}
+      util_caching
     )
 
     add_test(NAME ${TEST_TARGET_NAME}


### PR DESCRIPTION
This adds a GitHub Action testing the latest debian package by 

- downloading and installing the latest deb file from  
  https://github.com/KIT-MRT/util_caching/releases/latest/download/libutil-caching-dev.deb
- building unit tests against it (without local lib repo)
- running these tests