### PR TITLE
Improve unit test CMake setup

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -65,7 +65,7 @@ if(GTEST_FOUND)
     set(TEST_TARGET_NAME util_caching-gtest-${TEST_TARGET_NAME})
 
     message(STATUS
-      "Adding gtest unittest \"${TEST_TARGET_NAME}\" with working dir ${PROJECT_SOURCE_DIR}/${TEST_FOLDER} \n _test: ${_test}"
+      "Adding gtest unittest \"${TEST_TARGET_NAME}\" with working dir ${CMAKE_CURRENT_SOURCE_DIR}/${TEST_FOLDER} \n _test: ${_test}"
     )
 
     add_executable(${TEST_TARGET_NAME} ${_test})


### PR DESCRIPTION
Following our lessons learned from https://github.com/KIT-MRT/arbitration_graphs/commit/45756194f6962b7fa291e871cdbd99e3bdd3c020, this adds a tiny improvement of our test/CMakeLists.txt

This should help building the unit tests against installed lib

#patch