### PR TITLE
Compute version from PR description

### DIFF
--- a/.github/workflows/bump-version-and-create-release.yaml
+++ b/.github/workflows/bump-version-and-create-release.yaml
@@ -18,23 +18,14 @@ jobs:
       - name: Check out the repository
         uses: actions/checkout@v4
 
-      - name: Read version from file
-        run: |
-          # Read the version from the version file, only store the number (without the 'v')
-          INITIAL_VERSION=$(source version && echo ${VERSION#v})
-          echo "Current version: $INITIAL_VERSION"
-          echo "INITIAL_VERSION=${INITIAL_VERSION}" >> $GITHUB_ENV
-
-      - name: Bump version
+      - name: Compute new version
         id: bump_version
-        uses: anothrNick/github-tag-action@v1
         env:
-          DEFAULT_BUMP: minor
-          DRY_RUN: true
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          INITIAL_VERSION: ${{ env.INITIAL_VERSION }}
-          WITH_V: true
-
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          source version
+          new_version=$(.github/workflows/compute_version.sh "$VERSION" "${PR_BODY//[^a-zA-Z0-9# $'\n']/}")
+          echo "new_version=$new_version" >> $GITHUB_OUTPUT
 
   update-version-file:
     needs: compute-version

--- a/.github/workflows/bump-version-and-create-release.yaml
+++ b/.github/workflows/bump-version-and-create-release.yaml
@@ -13,7 +13,7 @@ jobs:
     permissions:
       contents: write
     outputs:
-      new_tag: ${{ steps.bump_version.outputs.new_tag }}
+      new_version: ${{ steps.bump_version.outputs.new_version }}
     steps:
       - name: Check out the repository
         uses: actions/checkout@v4
@@ -49,18 +49,18 @@ jobs:
 
       - name: Update version file with new version
         run: |
-          echo "New version: ${{ needs.compute-version.outputs.new_tag }}"
-          echo "VERSION=${{ needs.compute-version.outputs.new_tag }}" > version
+          echo "New version: ${{ needs.compute-version.outputs.new_version }}"
+          echo "VERSION=${{ needs.compute-version.outputs.new_version }}" > version
           git config --local user.name "github-actions[bot]"
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git add version
-          git commit -m "chore: update version file to ${{ needs.compute-version.outputs.new_tag }}"
+          git commit -m "chore: update version file to ${{ needs.compute-version.outputs.new_version }}"
           git push
 
       - name: Push new tag
         run: |
-          git tag ${{ needs.compute-version.outputs.new_tag }}
-          git push origin ${{ needs.compute-version.outputs.new_tag }}
+          git tag ${{ needs.compute-version.outputs.new_version }}
+          git push origin ${{ needs.compute-version.outputs.new_version }}
 
 
   create-release:
@@ -73,7 +73,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{ needs.compute-version.outputs.new_tag }}
+          ref: ${{ needs.compute-version.outputs.new_version }}
 
       - name: Build release packages
         uses: docker/build-push-action@v6
@@ -93,7 +93,7 @@ jobs:
         uses: ncipollo/release-action@v1
         with:
           artifacts: "/tmp/artifacts/release/*"
-          tag: ${{ needs.compute-version.outputs.new_tag }}
+          tag: ${{ needs.compute-version.outputs.new_version }}
           body: ${{ github.event.pull_request.body }}
 
 
@@ -105,7 +105,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           build-args: |
-            RELEASE_DOWNLOAD_URL=https://github.com/KIT-MRT/util_caching/releases/download/${{ needs.compute-version.outputs.new_tag }}
+            RELEASE_DOWNLOAD_URL=https://github.com/KIT-MRT/util_caching/releases/download/${{ needs.compute-version.outputs.new_version }}
           push: false
           tags: release_tester
           target: release_test

--- a/.github/workflows/compute_version.sh
+++ b/.github/workflows/compute_version.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+set -e
+
+if [[ $# -ne 2 ]]; then
+  echo "Usage: $0 <version> <input_string>"
+  exit 1
+fi
+
+initial_version=${1//[^0-9.]/}
+input_string=${2//[^a-zA-Z0-9# $'\n']/}
+
+initial_major=$(echo "$initial_version" | cut -d'.' -f1)
+initial_minor=$(echo "$initial_version" | cut -d'.' -f2)
+initial_patch=$(echo "$initial_version" | cut -d'.' -f3)
+
+# Determine the bump type based on input string
+if [[ "$input_string" == *"#major"* ]]; then
+  new_major=$((initial_major + 1))
+  new_minor=0
+  new_patch=0
+elif [[ "$input_string" == *"#minor"* ]]; then
+  new_major=$initial_major
+  new_minor=$((initial_minor + 1))
+  new_patch=0
+elif [[ "$input_string" == *"#patch"* ]]; then
+  new_major=$initial_major
+  new_minor=$initial_minor
+  new_patch=$((initial_patch + 1))
+else
+  # Default to minor bump
+  new_major=$initial_major
+  new_minor=$((initial_minor + 1))
+  new_patch=0
+fi
+
+new_version="v${new_major}.${new_minor}.${new_patch}"
+echo "${new_version}"
+


### PR DESCRIPTION
Analogous to https://github.com/KIT-MRT/arbitration_graphs/pull/85, the version bump is now computed from the PR description.

#patch